### PR TITLE
Added a "Provider ID" column to main table

### DIFF
--- a/AdminUI/Controllers/HomeController.cs
+++ b/AdminUI/Controllers/HomeController.cs
@@ -26,7 +26,7 @@ namespace AdminUI.Controllers
             _logger = logger;
         }
 
-        public IActionResult Index(string sortOrder, string pName, string cName, string dateFrom, string dateTo, string prime, string id)
+        public IActionResult Index(string sortOrder, string pName, string cName, string dateFrom, string dateTo, string prime, string id, string providerId)
         {
             var sheets = GetSheets();
 
@@ -38,31 +38,32 @@ namespace AdminUI.Controllers
                 model.PName = pName;
                 sheets = sheets.Where(t => t.ProviderName.ToLower().Contains(pName.ToLower()));
             }
+            if (!string.IsNullOrEmpty(providerId))
+            {
+                model.ProviderId = providerId;
+                sheets = sheets.Where(t => t.ProviderID.ToLower().Contains(providerId.ToLower()));
+            }
 
             if (!string.IsNullOrEmpty(cName))
             {
                 model.CName = cName;
                 sheets = sheets.Where(t => t.ClientName.ToLower().Contains(cName.ToLower()));
             }
-
+            if (!string.IsNullOrEmpty(prime))
+            {
+                model.Prime = prime;
+                sheets = sheets.Where(t => t.ClientPrime.ToLower().Contains(prime.ToLower()));
+            }
             if (!string.IsNullOrEmpty(dateFrom))
             {
                 model.DateFrom = dateFrom;
                 sheets = sheets.Where(t => t.Submitted >= DateTime.Parse(dateFrom));
             }
-
             if (!string.IsNullOrEmpty(dateTo))
             {
                 model.DateTo = dateTo;
                 sheets = sheets.Where(t => t.Submitted <= DateTime.Parse(dateTo));
             }
-
-            if (!string.IsNullOrEmpty(prime))
-            {
-                model.Prime = int.Parse(prime);
-                sheets = sheets.Where(t => t.ClientPrime == prime);
-            }
-
             if (!string.IsNullOrEmpty(id))
             {
                 model.Id = int.Parse(id);
@@ -107,6 +108,12 @@ namespace AdminUI.Controllers
                     break;
                 case "hours_desc":
                     sheets = sheets.OrderByDescending(t => t.Hours);
+                    break;
+                case "providerid":
+                    sheets = sheets.OrderBy(t => t.ProviderID);
+                    break;
+                case "providerid_desc":
+                    sheets = sheets.OrderByDescending(t => t.ProviderID);
                     break;
                 default:
                     sheets = sheets.OrderBy(t => t.TimesheetID);
@@ -176,7 +183,6 @@ namespace AdminUI.Controllers
                 catch (DbUpdateConcurrencyException)
                 {
 
-                    Console.WriteLine("There was an error");
                     if (!_context.Timesheet.Any(e => e.TimesheetID == id))
                     {
                         return NotFound();

--- a/AdminUI/Models/HomeModel.cs
+++ b/AdminUI/Models/HomeModel.cs
@@ -17,8 +17,9 @@ namespace AdminUI.Models
         public string PName; 
         public int? Id;
         public string CName;
-        public int? Prime;
+        public string Prime;
         public string DateFrom;
         public string DateTo;
+        public string ProviderId;
     }
 }

--- a/AdminUI/Views/Home/Index.cshtml
+++ b/AdminUI/Views/Home/Index.cshtml
@@ -39,12 +39,15 @@
         <label for="pName">Provider Name:</label>
         <input type="text" name="pName" id="pName" value ="@Model.PName">
         
-        <label for="prime">Prime:</label>
-        <input type="number" name="prime" id="prime" value ="@Model.Prime"><br/>
-        
+        <label for="pName">Provider ID:</label>
+        <input type="text" name="providerId" id="providerId" value ="@Model.ProviderId">
+
         <label for="cName">Client Name:</label>
         <input type="text" name="cName" id="cName" value="@Model.CName">
         
+        <label for="prime">Client Prime:</label>
+        <input type="text" name="prime" id="prime" value ="@Model.Prime">
+
         <label for="dateFrom">From:</label>
         <input type="date" name="dateFrom" id="dateFrom" value="@Model.DateFrom">
         
@@ -117,11 +120,11 @@
 
                         })</th>
                 }
-                @if (Model.SortOrder == "prime")
+                @if (Model.SortOrder == "providerid")
                 {
-                    <th>@Html.ActionLink("Prime", "Index", new
+                    <th>@Html.ActionLink("Provider ID", "Index", new
                         {
-                            sortOrder = "prime_desc",
+                            sortOrder = "providerid_desc",
                             id = Model.Id,
                             pname = Model.PName,
                             prime = Model.Prime,
@@ -132,10 +135,9 @@
                 }
                 else
                 {
-
-                    <th>@Html.ActionLink("Prime", "Index", new
+                    <th>@Html.ActionLink("Provider ID", "Index", new
                         {
-                            sortOrder = "prime",
+                            sortOrder = "providerid",
                             id = Model.Id,
                             pname = Model.PName,
                             prime = Model.Prime,
@@ -163,6 +165,32 @@
                     <th>@Html.ActionLink("Client Name", "Index", new
                         {
                             sortOrder = "cname",
+                            id = Model.Id,
+                            pname = Model.PName,
+                            prime = Model.Prime,
+                            cname = Model.CName,
+                            datefrom = Model.DateFrom,
+                            dateto = Model.DateTo
+                        })</th>
+                }
+                @if (Model.SortOrder == "prime")
+                {
+                    <th>@Html.ActionLink("Client Prime", "Index", new
+                        {
+                            sortOrder = "prime_desc",
+                            id = Model.Id,
+                            pname = Model.PName,
+                            prime = Model.Prime,
+                            cname = Model.CName,
+                            datefrom = Model.DateFrom,
+                            dateto = Model.DateTo
+                        })</th>
+                }
+                else
+                {
+                    <th>@Html.ActionLink("Client Prime", "Index", new
+                        {
+                            sortOrder = "prime",
                             id = Model.Id,
                             pname = Model.PName,
                             prime = Model.Prime,
@@ -235,8 +263,9 @@
                 <tr class ="color-div" style="background-color: @color">
                     <td>@Html.ActionLink(@t.TimesheetID.ToString(), "Timesheet", new {ID = @t.TimesheetID})</td>
                     <td>@t.ProviderName</td>
-                    <td>@t.ClientPrime</td>
+                    <td>@t.ProviderID</td>
                     <td>@t.ClientName</td>
+                    <td>@t.ClientPrime</td>
                     <td>@t.Hours</td>
                     <td>@t.Submitted</td>
                 </tr>


### PR DESCRIPTION
On the homepage, there now exists a "Provider ID" column in the main table.
I made sure the column is sortable, and added a filter that allows Provider ID to be filtered.
I also renamed "Prime" to "Client Prime" to avoid confusion

Signed-off-by John Brusaw <jbrusaw@pdx.edu>