### PR TITLE
Combined localdb into one database

### DIFF
--- a/AdminUI/Startup.cs
+++ b/AdminUI/Startup.cs
@@ -30,9 +30,9 @@ namespace AdminUI
             services.AddControllersWithViews();
             services.AddProgressiveWebApp();
             services.AddDbContext<TimesheetContext>(options =>
-                options.UseSqlServer(Configuration.GetConnectionString("LocalTestDB")));
+                options.UseSqlServer(Configuration.GetConnectionString("localdb")));
             services.AddDbContext<AdminAccountContext>(options =>
-                options.UseSqlServer(Configuration.GetConnectionString("LocalAdminAccountDB")));
+                options.UseSqlServer(Configuration.GetConnectionString("localdb")));
             services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = true)
                 .AddEntityFrameworkStores<AdminAccountContext>();
             services.AddRazorPages();

--- a/AdminUI/appsettings.json
+++ b/AdminUI/appsettings.json
@@ -8,7 +8,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "LocalTestDB": "Server=(localdb)\\mssqllocaldb;Database=TimesheetContext;Trusted_Connection=True;MultipleActiveResultSets=true;",
-    "LocalAdminAccountDB": "Server=(localdb)\\mssqllocaldb;Database=AdminAccountContext;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "localdb": "Server=(localdb)\\mssqllocaldb;Database=localdb;Trusted_Connection=True;MultipleActiveResultSets=true;"
   }
 }


### PR DESCRIPTION
Previously, we had 2 localdbs for each context. I realized this is unnecessary, so I combined the two and renamed the local db.

Run these two commands in Package Manager to apply updates

EntityFrameworkCore\Update-Database -Context AdminAccountContext

EntityFrameworkCore\Update-Database -Context TimesheetContext

Signed-off-by John Brusaw <jbrusaw@pdx.edu>