### PR TITLE
Clickable Rows and Timesheet Status Filtering

### DIFF
--- a/AdminUI/Controllers/HomeController.cs
+++ b/AdminUI/Controllers/HomeController.cs
@@ -30,7 +30,7 @@ namespace AdminUI.Controllers
             _Lcontext = Lcontext;
         }
 
-        public IActionResult Index(string sortOrder, string pName, string cName, string dateFrom, string dateTo, string prime, string id, string providerId)
+        public IActionResult Index(string sortOrder, string pName, string cName, string dateFrom, string dateTo, string prime, string id, string providerId, string status)
         {
             var sheets = GetSheets();
 
@@ -56,7 +56,7 @@ namespace AdminUI.Controllers
             if (!string.IsNullOrEmpty(prime))
             {
                 model.Prime = prime;
-                sheets = sheets.Where(t => t.ClientPrime.ToLower().Contains(prime.ToLower()));
+                sheets = sheets.Where(t => t.ClientPrime.Contains(prime, StringComparison.CurrentCultureIgnoreCase));
             }
             if (!string.IsNullOrEmpty(dateFrom))
             {
@@ -73,57 +73,34 @@ namespace AdminUI.Controllers
                 model.Id = int.Parse(id);
                 sheets = sheets.Where(t => t.TimesheetID == int.Parse(id));
             }
+            
+            if (string.IsNullOrEmpty(status))
+                status = "pending";
+            
+            if(!string.Equals(status,"all",StringComparison.CurrentCultureIgnoreCase))
+                sheets = sheets.Where(t => t.Status.Equals(status,StringComparison.CurrentCultureIgnoreCase));
+            
+            model.Status = status;
 
             //big ol' switch statement determines how to sort the data in the table
-            switch (sortOrder)
-            { 
-                case "id":
-                    sheets = sheets.OrderBy(t => t.TimesheetID);
-                    break;
-                case "id_desc":
-                    sheets = sheets.OrderByDescending(t => t.TimesheetID);
-                    break;
-                case "pname":
-                    sheets = sheets.OrderBy(t => t.ProviderName);
-                    break;
-                case "pname_desc":
-                    sheets = sheets.OrderByDescending(t => t.ProviderName);
-                    break;
-                case "prime":
-                    sheets = sheets.OrderBy(t => t.ClientPrime);
-                    break;
-                case "prime_desc":
-                    sheets = sheets.OrderByDescending(t => t.ClientPrime);
-                    break;
-                case "cname":
-                    sheets = sheets.OrderBy(t => t.ClientName);
-                    break;
-                case "cname_desc":
-                    sheets = sheets.OrderByDescending(t => t.ClientName);
-                    break;
-                case "date":
-                    sheets = sheets.OrderBy(t => t.Submitted);
-                    break;
-                case "date_desc":
-                    sheets = sheets.OrderByDescending(t => t.Submitted);
-                    break;
-                case "hours":
-                    sheets = sheets.OrderBy(t => t.Hours);
-                    break;
-                case "hours_desc":
-                    sheets = sheets.OrderByDescending(t => t.Hours);
-                    break;
-                case "providerid":
-                    sheets = sheets.OrderBy(t => t.ProviderID);
-                    break;
-                case "providerid_desc":
-                    sheets = sheets.OrderByDescending(t => t.ProviderID);
-                    break;
-                default:
-                    sheets = sheets.OrderBy(t => t.TimesheetID);
-                    break;
-            }
-
+            sheets = sortOrder switch
+            {
+                "id" => sheets.OrderBy(t => t.TimesheetID),
+                "id_desc" => sheets.OrderByDescending(t => t.TimesheetID),
+                "pname" => sheets.OrderBy(t => t.ProviderName),
+                "pname_desc" => sheets.OrderByDescending(t => t.ProviderName),
+                "prime" => sheets.OrderBy(t => t.ClientPrime),
+                "prime_desc" => sheets.OrderByDescending(t => t.ClientPrime),
+                "cname" => sheets.OrderBy(t => t.ClientName),
+                "cname_desc" => sheets.OrderByDescending(t => t.ClientName),
+                "date" => sheets.OrderBy(t => t.Submitted),
+                "date_desc" => sheets.OrderByDescending(t => t.Submitted),
+                "hours" => sheets.OrderBy(t => t.Hours),
+                "hours_desc" => sheets.OrderByDescending(t => t.Hours),
+                "providerid" => sheets.OrderBy(t => t.ProviderID),
+                "providerid_desc" => sheets.OrderByDescending(t => t.ProviderID),
+                _ => sheets.OrderBy(t => t.TimesheetID),
+            };
             model.SortOrder = sortOrder;
             model.Sheets = new List<Timesheet>(sheets);
             return View(model);
@@ -182,7 +159,7 @@ namespace AdminUI.Controllers
             return View(timesheet);
         }
 
-        public FileContentResult DownloadCSV(string pName, string cName, string dateFrom, string dateTo, string prime, string id)
+        public FileContentResult DownloadCSV(string pName, string cName, string dateFrom, string dateTo, string prime, string id, string status)
         {
             var sheets = GetSheets();
 
@@ -205,6 +182,12 @@ namespace AdminUI.Controllers
 
             if (!string.IsNullOrEmpty(id))
                 sheets = sheets.Where(t => t.TimesheetID == int.Parse(id));
+
+            if (string.IsNullOrEmpty(status))
+                status = "pending";
+
+            if(!string.Equals(status,"all",StringComparison.CurrentCultureIgnoreCase))
+                sheets = sheets.Where(t => t.Status.Equals(status,StringComparison.CurrentCultureIgnoreCase));
 
             //the following loops through every property in a timesheet, first saving the names of the properties to 
             //act as a header. Then, it loops through every timesheet, adding every individual property of the timesheet

--- a/AdminUI/Models/HomeModel.cs
+++ b/AdminUI/Models/HomeModel.cs
@@ -21,5 +21,6 @@ namespace AdminUI.Models
         public string DateFrom;
         public string DateTo;
         public string ProviderId;
+        public string Status;
     }
 }

--- a/AdminUI/Views/Home/Index.cshtml
+++ b/AdminUI/Views/Home/Index.cshtml
@@ -22,9 +22,9 @@
         <div class ="text-center">
             <div class="leftnav">
                 <p>Saved filters</p>
-                @Html.ActionLink("Submitted by Mickey Mouse", "Index", new {pname = "Mickey Mouse"})
-                @Html.ActionLink("Submitted since 4/2/2020", "Index", new {datefrom = "2020-04-02"})
-                @Html.ActionLink("All unprocessed Timesheets", "Index", new {})
+                @Html.ActionLink("Submitted by Mickey Mouse", "Index", new {pname = "Mickey Mouse", status="all"})
+                @Html.ActionLink("Submitted since 4/2/2020", "Index", new {datefrom = "2020-04-02", status = "all"})
+                @Html.ActionLink("All unprocessed Timesheets", "Index", new {status="pending"})
             </div>
         </div>
 }
@@ -52,13 +52,46 @@
                 </div>
                 <div class="col-md-3">
                     <label for="status">Status:</label>
-                    <input type="text" name="status" id="status" value="@Model.Id"/>
+                    <select name="status" id="status">
+                        @if (Model.Status.Equals("all", StringComparison.CurrentCultureIgnoreCase))
+                        {
+                            <option value="all" selected>All</option>
+                        }
+                        else
+                        {
+                            <option value="all">All</option>
+                        }
+                        @if (Model.Status.Equals("pending", StringComparison.CurrentCultureIgnoreCase))
+                        {
+                            <option value="pending" selected>Pending</option>
+                        }
+                        else
+                        {
+                            <option value="pending">Pending</option>
+                        }
+                        @if (Model.Status.Equals("approved", StringComparison.CurrentCultureIgnoreCase))
+                        {
+                            <option value="approved" selected>Approved</option>
+                        }
+                        else
+                        {
+                            <option value="approved">Approved</option>
+                        }
+                        @if (Model.Status.Equals("rejected", StringComparison.CurrentCultureIgnoreCase))
+                        {
+                            <option value="rejected" selected>Rejected</option>
+                        }
+                        else
+                        {
+                            <option value="rejected">Rejected</option>
+                        }
+                    </select>
                 </div>
             </div>
             <div class="row text-right">
                 <div class="col-md-3">
                     <label for="pName">Provider ID:</label>
-                    <input type="text" name="providerId" id="providerId" value="@Model.ProviderId">
+                    <input type="select" name="providerId" id="providerId" value="@Model.ProviderId">
                 </div>
                 <div class="col-md-3">
                     <label for="prime">Client Prime:</label>
@@ -83,6 +116,7 @@
                 cname = Model.CName,
                 datefrom = Model.DateFrom,
                 dateto = Model.DateTo,
+                status = Model.Status
             }, new
             {
                 @class = "btn btn-secondary "
@@ -296,13 +330,13 @@
             color = color == "#8FDDE6" ? "#E6EFF3" : "#8FDDE6";
         }
         <tr class="color-div" style="background-color: @color">
-            <td>@Html.ActionLink(@t.TimesheetID.ToString(), "Timesheet", new {ID = @t.TimesheetID})</td>
-            <td>@t.ProviderName</td>
-            <td>@t.ProviderID</td>
-            <td>@t.ClientName</td>
-            <td>@t.ClientPrime</td>
-            <td>@t.Hours</td>
-            <td>@t.Submitted</td>
+            <td><a asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.TimesheetID</a></td>
+            <td><a asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.ProviderName</a></td>
+            <td><a asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.ProviderID</a></td>
+            <td><a asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.ClientName</a></td>
+            <td><a asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.ClientPrime</a></td>
+            <td><a asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.Hours</a></td>
+            <td><a asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.Submitted</a></td>
         </tr>
     }
     </table>

--- a/AdminUI/Views/Home/Timesheet.cshtml
+++ b/AdminUI/Views/Home/Timesheet.cshtml
@@ -155,7 +155,7 @@
                         <input type="hidden" name="id" value="@Model.TimesheetID"/>
                         <input onclick="handleRejected" class="btn btn-danger" name="Status" value="Rejected" type="submit">
                         <input type="text" name="RejectionReason"/>
-                        <input onclick="handleAccepted" class="btn btn-primary" name="Status" value="Accepted" type="submit">
+                        <input onclick="handleAccepted" class="btn btn-primary" name="Status" value="Approved" type="submit">
                     </div>
                 </form>
             </div>

--- a/AdminUI/wwwroot/css/site.css
+++ b/AdminUI/wwwroot/css/site.css
@@ -104,6 +104,7 @@
 .color-div:hover {
     filter: brightness(90%);
     transition: .3s;
+    text-decoration: underline;
 }
 
 .color-div a {
@@ -121,6 +122,10 @@ a.navbar-brand {
 /* Provide sufficient contrast against white background */
 a {
   color: #0366d6;
+}
+
+td a {
+    display: block;
 }
 
 .btn-primary {

--- a/AdminUITest/HomeControllerTest.cs
+++ b/AdminUITest/HomeControllerTest.cs
@@ -29,7 +29,7 @@ namespace AdminUI.Tests
         public void IndexTest_IsNotNull()
         {
             var hc = new HomeController(_logger, _dbcontext,_ltcontext);
-            var result = (ViewResult)hc.Index("sortOrder", "pName", "cName", "01/01/2020", "01/14/2020", "123456", "1", "P123456");
+            var result = (ViewResult)hc.Index("sortOrder", "pName", "cName", "01/01/2020", "01/14/2020", "123456", "1", "P123456", "pending");
             Assert.IsNotNull(result.ViewData);
         }
     }


### PR DESCRIPTION
This commmit accomplished two things:
1. The entire row of the main table is now clickable, opening a
   timesheet
2. I added a status filter and set the default to "pending" so that
   pending timesheets are the default sheets when loading AdminUI

Signed-off-by: John Brusaw <jwbrusaw@gmail.com>