### PR TITLE
Timesheet popup

### DIFF
--- a/AdminUI/Controllers/HomeController.cs
+++ b/AdminUI/Controllers/HomeController.cs
@@ -102,6 +102,63 @@ namespace AdminUI.Controllers
                 _ => sheets.OrderBy(t => t.TimesheetID),
             };
             model.SortOrder = sortOrder;
+
+            foreach (var t in sheets)
+            {
+                t.Shifts = new List<Shift>
+                {
+                    new Shift
+                    {
+                        Date = DateTime.Parse("3/11/2020"),
+                        In = DateTime.Parse("11:30 AM"),
+                        Out = DateTime.Parse("7:30 PM"),
+                        Hours = 8.00,
+                        Group = false
+                    },
+                    new Shift
+                    {
+                        Date = DateTime.Parse("3/11/2020"),
+                        In = DateTime.Parse("11:30 AM"),
+                        Out = DateTime.Parse("7:30 PM"),
+                        Hours = 8.00,
+                        Group = false
+                    },
+                    new Shift
+                    {
+                        Date = DateTime.Parse("3/11/2020"),
+                        In = DateTime.Parse("11:30 AM"),
+                        Out = DateTime.Parse("7:30 PM"),
+                        Hours = 8.00,
+                        Group = false
+                    },
+                    new Shift
+                    {
+                        Date = DateTime.Parse("3/11/2020"),
+                        In = DateTime.Parse("11:30 AM"),
+                        Out = DateTime.Parse("7:30 PM"),
+                        Hours = 8.00,
+                        Group = false
+                    },
+                    new Shift
+                    {
+                        Date = DateTime.Parse("3/11/2020"),
+                        In = DateTime.Parse("11:30 AM"),
+                        Out = DateTime.Parse("7:30 PM"),
+                        Hours = 8.00,
+                        Group = false
+                    },
+                    new Shift
+                    {
+                        Date = DateTime.Parse("3/12/2020"),
+                        In = DateTime.Parse("11:30 AM"),
+                        Out = DateTime.Parse("7:30 PM"),
+                        Hours = 8.00,
+                        Group = false
+                    }
+                };
+            }
+
+
             model.Sheets = new List<Timesheet>(sheets);
             return View(model);
         }

--- a/AdminUI/Views/Home/Index.cshtml
+++ b/AdminUI/Views/Home/Index.cshtml
@@ -330,14 +330,97 @@
             color = color == "#8FDDE6" ? "#E6EFF3" : "#8FDDE6";
         }
         <tr class="color-div" style="background-color: @color">
-            <td><a asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.TimesheetID</a></td>
-            <td><a asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.ProviderName</a></td>
-            <td><a asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.ProviderID</a></td>
-            <td><a asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.ClientName</a></td>
-            <td><a asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.ClientPrime</a></td>
-            <td><a asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.Hours</a></td>
-            <td><a asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.Submitted</a></td>
+            <td><a data-toggle="modal" data-target="#@("sheet" + t.TimesheetID)" asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.TimesheetID</a></td>
+            <td><a data-toggle="modal" data-target="#@("sheet" + t.TimesheetID)" asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.ProviderName</a></td>
+            <td><a data-toggle="modal" data-target="#@("sheet" + t.TimesheetID)" asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.ProviderID</a></td>
+            <td><a data-toggle="modal" data-target="#@("sheet" + t.TimesheetID)" asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.ClientName</a></td>
+            <td><a data-toggle="modal" data-target="#@("sheet" + t.TimesheetID)" asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.ClientPrime</a></td>
+            <td><a data-toggle="modal" data-target="#@("sheet" + t.TimesheetID)" asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.Hours</a></td>
+            <td><a data-toggle="modal" data-target="#@("sheet" + t.TimesheetID)" asp-action="Timesheet" asp-route-id="@t.TimesheetID">@t.Submitted</a></td>
         </tr>
+        <div class="modal fade" id="@("sheet" + t.TimesheetID)" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+            <div class="modal-dialog modal-lg" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="exampleModalLabel">@t.ProviderName (@t.ProviderID)</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="flex-container column">
+                            <div class="row">
+                                <div class="column">
+                                    @if (String.IsNullOrEmpty(t.Status) || t.Status.Equals("Pending", StringComparison.CurrentCultureIgnoreCase))
+                                    {
+                                        <label asp-for="Status">Status:</label> <span>Pending</span>
+                                    }
+                                    else
+                                    {
+                                        <label asp-for="Status">Status:</label> @t.AdminActivity
+                                    }
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="column">
+                                    <label for="client-name">Client Name:</label> @t.ClientName
+                                </div>
+                                <div class="column">
+                                    <label for="prime">Client Prime:</label> @t.ClientPrime
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="column">
+                                    <label>Total Hours:</label>  @t.Hours
+                                </div>
+                                <div class="column">
+                                    <label>Timesheet Submitted on:</label> @t.Submitted.ToString("MM-dd-yyyy")
+                                </div>
+                            </div>
+                                <div class="table">
+                                    <div class ="row" style="background-color: #0294B5">
+                                        <div class="col"><b>Date</b></div>
+                                        <div class="col"><b>Start/Time IN</b></div>
+                                        <div class="col"><b>End/Time OUT</b></div>
+                                        <div class="col"><b>Hours</b></div>
+                                        <div class="col"><b>Group? (yes/no)</b></div>
+                                    </div>
+                                    @foreach (var s in t.Shifts)
+                                    {
+
+                                        color = color == "#8FDDE6" ? "#E6EFF3" : "#8FDDE6";
+                                        <div class="row" style="background-color:@color">
+                                            <div class="col">@s.Date.ToString("d")</div>
+                                            <div class="col">@s.In.ToString("h:mm tt")</div>
+                                            <div class="col">@s.Out.ToString("h:mm tt")</div>
+                                            <div class="col">@s.Hours</div>
+                                            @if (s.Group)
+                                            {
+                                                <div class="col">Yes</div>
+                                            }
+                                            else
+                                            {
+                                                <div class="col">No</div>
+
+                                            }
+                                        </div>
+                                    }
+
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <a class="btn btn-secondary" asp-action="Timesheet" asp-route-id="@t.TimesheetID">More Details</a>
+                        <form asp-controller="Timesheet" asp-action="Process">
+                            <input type="hidden" name="id" value="@t.TimesheetID"/>
+                            <input class="btn btn-primary" name="Status" value="Approved" type="submit">
+                            <input class="btn btn-danger" name="Status" value="Rejected" type="submit">
+                            <input type="text" name="RejectionReason" placeholder="Rejection Reason"/>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
     }
     </table>
     @if (Model.Sheets.Count == 0)


### PR DESCRIPTION
Popup Windows

When you left-click a timesheet from the home page, a popup modal
displays containing summary information about the timesheet. You can
also accept or reject a timesheet from this modal. Middle-clicking
or opening the timesheet in a new tab takes you straight to the
details page.

Currently there is no way to check a lock or gain the lock before trying
to accept/reject. This is because the modal is opened without ever
calling a controller, and it would take an excessive amount of C# code
in the view to accomplish this, which is considered bad practice. We'll
need to adress the best way to handle this later

Signed-off-by: John Brusaw <jwbrusaw@gmail.com>