### PR TITLE
Fixed DateTo Bug

### DIFF
--- a/AdminUI/Controllers/HomeController.cs
+++ b/AdminUI/Controllers/HomeController.cs
@@ -72,12 +72,12 @@ namespace AdminUI.Controllers
             if (!string.IsNullOrEmpty(dateTo))
             {
                 model.DateTo = dateTo;
-                submissions = submissions.Where(t => t.Submitted <= DateTime.Parse(dateTo));
+                submissions = submissions.Where(t => t.Submitted <= DateTime.Parse(dateTo).AddDays(1));
             }
             else if (GlobalVariables.CurrentPayPeriod != null)
             {
                 model.DateTo = GlobalVariables.CurrentPayPeriod.DateTo.ToString("yyyy-MM-dd");
-                submissions = submissions.Where(t => t.Submitted <= GlobalVariables.CurrentPayPeriod.DateTo);
+                submissions = submissions.Where(t => t.Submitted <= GlobalVariables.CurrentPayPeriod.DateTo.AddDays(1));
             }
 
             if(!string.Equals(status,"all",StringComparison.CurrentCultureIgnoreCase))


### PR DESCRIPTION
Simply added a day to DateTo before filtering so now dates are filtered
by <= DateTo.AddDays(1). Now the DateTo is inclusive of the selected
date

Signed-off-by: John Brusaw <jwbrusaw@gmail.com>