### PR TITLE
Fixed front page detection

### DIFF
--- a/Appserver/FormSubmit/AbstractFormObject.cs
+++ b/Appserver/FormSubmit/AbstractFormObject.cs
@@ -74,12 +74,28 @@ public abstract class AbstractFormObject{
         bool frontfound = false;
         List<Page> backpages = new List<Page>();
 
+        // Improve front page detection
         foreach (var page in doc.Pages)
         {
-            if (page.GetTables().Count >= 1 && page.GetFormItems().Count < 8)
+            if (!frontfound)
             {
-                frontpage = page;
-                frontfound = true;
+                // Search for Service Delivered On:
+                foreach (var line in page.GetLines())
+                {
+                    // Ever form has "Service Delivered On:" on the front page, so we use
+                    // this to determine if this is the front or back.
+                    frontfound = line.ToString().Contains("vice Delivered O");
+                    if (frontfound)
+                        break;
+                }
+                if (frontfound)
+                {
+                    frontpage = page;
+                }
+                else
+                {
+                    backpages.Add(page);
+                }
             }
             else
             {

--- a/Appserver/TextractDocument/Page.cs
+++ b/Appserver/TextractDocument/Page.cs
@@ -52,6 +52,7 @@ namespace Appserver.TextractDocument
 
         public List<KeyValuePair<KeyValueSet, KeyValueSet>> GetFormItems() => _keyvaluepairs;
         public List<Table> GetTables() => _tables;
+        public List<Line> GetLines() => _lines;
 
         /*******************************************************************************
         /// Methods


### PR DESCRIPTION
This works better for detecting the front page, thought there is
a requirement that the entire phrase "Service Delivered On:" is on
the form and is read correctly. This will be fixed when we implement
fuzzy string matching.

Signed-off-by: David Post <post@pdx.edu>