### PR TITLE
Fixed selection item exception

### DIFF
--- a/Appserver/FormSubmit/AbstractFormObject.cs
+++ b/Appserver/FormSubmit/AbstractFormObject.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
+using Microsoft.EntityFrameworkCore.Internal;
 
 public abstract class AbstractFormObject {
 
@@ -328,7 +329,9 @@ public abstract class AbstractFormObject {
                     providerSignDate = ConvertDate(item.Value.ToString().Trim());
             }
         }
-        formDict.Add("", ""); // Add in empty string match for missing items
+
+        if( !formDict.ContainsKey("") )
+            formDict.Add("", ""); // Add in empty string match for missing items
 
         serviceGoal = formDict[mapping[keys[0]]];
         progressNotes = formDict[mapping[keys[1]]];

--- a/Appserver/TextractDocument/SelectionElement.cs
+++ b/Appserver/TextractDocument/SelectionElement.cs
@@ -54,10 +54,15 @@ namespace Appserver.TextractDocument
                     _childIds.Add(child.ToString());
                 }
             }
-            catch (System.ArgumentNullException e)
+            catch (System.ArgumentNullException)
             {
                 // suppress error
                 return;
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // No relationships
+                return; 
             }
         }
         /*******************************************************************************
@@ -74,6 +79,7 @@ namespace Appserver.TextractDocument
         {
             _parent = page;
         }
+        public bool GetSelectionStatus() => SelectionStatus;
 
         /*******************************************************************************
         /// Methods


### PR DESCRIPTION
In some cases there are no relations and it throws an error. We simply
catch this and move on.

Also fixes an error in the AbstractFormObject where an empty string key
is already added.

Signed-off-by: David Post <post@pdx.edu>