### PR TITLE
Added express middleware to handle the 404 error from refreshing pages

### DIFF
--- a/PWA/package-lock.json
+++ b/PWA/package-lock.json
@@ -5026,8 +5026,7 @@
     "connect-history-api-fallback": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
-      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
-      "dev": true
+      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
     },
     "console-browserify": {
       "version": "1.2.0",
@@ -12737,17 +12736,6 @@
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
-    },
-    "os-locale": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-      "dev": true,
-      "requires": {
-        "execa": "^1.0.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
-      }
     },
     "os-tmpdir": {
       "version": "1.0.2",

--- a/PWA/package.json
+++ b/PWA/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "axios": "^0.19.2",
     "bufferutil": "^4.0.1",
+    "connect-history-api-fallback": "^1.6.0",
     "depcheck": "^0.9.2",
     "dotenv-webpack": "^1.8.0",
     "es6-promise": "^4.2.8",

--- a/PWA/server.js
+++ b/PWA/server.js
@@ -1,7 +1,10 @@
 const express = require('express');
 const serveStatic = require("serve-static")
 const path = require('path');
+const history = require('connect-history-api-fallback');
+  
 let app = express();
+app.use(history());
 app.use(serveStatic(path.join(__dirname, 'dist')));
 const port = process.env.PORT || 80;
 let listener = app.listen(port, function(){


### PR DESCRIPTION
This addresses the 'refresh error' shown by Larry. The source of this error is due to the usage of 'history' mode for the vue router, which removed the '#' from the url. This change required the usage of an express middleware in order to cache the history route, thus solving the refresh error.

Signed-off-by: Lenovo Windows - Yves Wienecke <whyves@icloud.com>