### PR TITLE
Prevented last row of table from being removed

### DIFF
--- a/Appserver/FormSubmit/AbstractFormObject.cs
+++ b/Appserver/FormSubmit/AbstractFormObject.cs
@@ -3,8 +3,10 @@ using Appserver.TextractDocument;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
+using System.Text.RegularExpressions;
 
-public abstract class AbstractFormObject {
+public abstract class AbstractFormObject{
 
     /*******************************************************************************
     /// Enums
@@ -361,6 +363,82 @@ public abstract class AbstractFormObject {
             }
         }
         return matches;
+    }
+
+    // If one of the rows in the cell matches the regex
+    // and there is also a row that can be parsed into hours,
+    // then we probably have a total hours cell. 
+    public static bool isTotalTimeRow(List<Cell> lastrow)
+    {
+        // The letters of "total/unit/hours" without
+        // "yes/no" for group field.
+        Regex rxTotal = new Regex(@"([uthrli])+");
+        Regex rxTime = new Regex(@"([0-9])+");
+        bool matchRex = false;
+        bool matchTime = false;
+
+        foreach(var entry in lastrow)
+        {
+            // TotalHours match?
+            var s = entry.ToString().Trim().ToLower();
+            var totalmatches = rxTotal.Matches(s);
+            if(totalmatches.Count >= 1){ matchRex = true; }
+
+            // Time match?
+            var time = FixHours(entry.ToString()).ToString().Trim();
+            var timeMatches = rxTime.Matches(time.ToLower());
+            if(timeMatches.Count >=1) { matchTime = true; }
+        }
+
+        return matchRex && matchTime;
+    }
+
+
+    public static bool isTotalMilesRow(List<Cell> lastrow)
+    {
+        Regex rxNumberGroup = new Regex(@"([0-9])+");
+        int confidence = 0;
+        bool foundDate = false;
+
+        foreach(var entry in lastrow)
+        {
+            var s = entry.ToString().Trim().ToLower();
+
+            // If we can parse the entry into a valid
+            // DateTime format, probably areen't dealing
+            // with a total miles row.
+            try
+            {
+                var date = DateTime.Parse(s).ToString("yyyy-MM-dd");
+                foundDate = true;           
+            }
+            catch (FormatException){}
+
+            // Increase confidence we have a total miles row
+            if (s.Contains("total"))
+            {
+                confidence++;
+            }
+
+            if (s.Contains("miles"))
+            {
+                confidence++;
+            }
+
+            var matches = rxNumberGroup.Matches(s);
+            confidence += matches.Count;
+        }
+
+        // Most likely a mileage entry
+        if (foundDate)
+        {
+            return false;
+        }
+
+        // Did we at least find a contains words
+        // and at least one group of numbers that could
+        // be a mileage total?
+        return confidence >= 2;
     }
 
     protected abstract void AddTables(List<Table> tables);

--- a/Appserver/FormSubmit/AbstractFormObject.cs
+++ b/Appserver/FormSubmit/AbstractFormObject.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
-using System.Text.RegularExpressions;
 
 public abstract class AbstractFormObject{
 
@@ -365,81 +364,6 @@ public abstract class AbstractFormObject{
         return matches;
     }
 
-    // If one of the rows in the cell matches the regex
-    // and there is also a row that can be parsed into hours,
-    // then we probably have a total hours cell. 
-    public static bool isTotalTimeRow(List<Cell> lastrow)
-    {
-        // The letters of "total/unit/hours" without
-        // "yes/no" for group field.
-        Regex rxTotal = new Regex(@"([uthrli])+");
-        Regex rxTime = new Regex(@"([0-9])+");
-        bool matchRex = false;
-        bool matchTime = false;
-
-        foreach(var entry in lastrow)
-        {
-            // TotalHours match?
-            var s = entry.ToString().Trim().ToLower();
-            var totalmatches = rxTotal.Matches(s);
-            if(totalmatches.Count >= 1){ matchRex = true; }
-
-            // Time match?
-            var time = FixHours(entry.ToString()).ToString().Trim();
-            var timeMatches = rxTime.Matches(time.ToLower());
-            if(timeMatches.Count >=1) { matchTime = true; }
-        }
-
-        return matchRex && matchTime;
-    }
-
-
-    public static bool isTotalMilesRow(List<Cell> lastrow)
-    {
-        Regex rxNumberGroup = new Regex(@"([0-9])+");
-        int confidence = 0;
-        bool foundDate = false;
-
-        foreach(var entry in lastrow)
-        {
-            var s = entry.ToString().Trim().ToLower();
-
-            // If we can parse the entry into a valid
-            // DateTime format, probably areen't dealing
-            // with a total miles row.
-            try
-            {
-                var date = DateTime.Parse(s).ToString("yyyy-MM-dd");
-                foundDate = true;           
-            }
-            catch (FormatException){}
-
-            // Increase confidence we have a total miles row
-            if (s.Contains("total"))
-            {
-                confidence++;
-            }
-
-            if (s.Contains("miles"))
-            {
-                confidence++;
-            }
-
-            var matches = rxNumberGroup.Matches(s);
-            confidence += matches.Count;
-        }
-
-        // Most likely a mileage entry
-        if (foundDate)
-        {
-            return false;
-        }
-
-        // Did we at least find a contains words
-        // and at least one group of numbers that could
-        // be a mileage total?
-        return confidence >= 2;
-    }
 
     protected abstract void AddTables(List<Table> tables);
     protected void AddBackForm(Page page)

--- a/Appserver/FormSubmit/MileageForm.cs
+++ b/Appserver/FormSubmit/MileageForm.cs
@@ -1,6 +1,9 @@
 ﻿using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Linq;
+using System;
+using Appserver.TextractDocument;
+using System.Text.RegularExpressions;
 
 namespace Appserver.FormSubmit
 {
@@ -27,8 +30,7 @@ namespace Appserver.FormSubmit
         public void addMileRow(string date, string miles, string group, string purpose) =>
             this.Mileage.Add(new MileageRowItem(date, miles, group, purpose));
 
-
-        protected override void AddTables(List<TextractDocument.Table> tables)
+        protected override void AddTables(List<Table> tables)
         {
             var table = tables[0].GetTable();
             // Remove first row
@@ -66,6 +68,58 @@ namespace Appserver.FormSubmit
             {
                 totalMiles = lastrow[1].ToString().Trim();
             }
+            else
+            {
+                totalMiles = "0";
+            }
+        }
+
+
+        public static bool isTotalMilesRow(List<Cell> lastrow)
+        {
+            Regex rxNumberGroup = new Regex(@"([0-9])+");
+            int confidence = 0;
+            bool foundDate = false;
+
+            foreach (var entry in lastrow)
+            {
+                var s = entry.ToString().Trim().ToLower();
+
+                // If we can parse the entry into a valid
+                // DateTime format, probably areen't dealing
+                // with a total miles row.
+                try
+                {
+                    var date = DateTime.Parse(s).ToString("yyyy-MM-dd");
+                    foundDate = true;
+                }
+                catch (FormatException) { }
+
+                // Increase confidence we have a total miles row
+                if (s.Contains("total"))
+                {
+                    confidence++;
+                }
+
+                if (s.Contains("miles"))
+                {
+                    confidence++;
+                }
+
+                var matches = rxNumberGroup.Matches(s);
+                confidence += matches.Count;
+            }
+
+            // Most likely a mileage entry
+            if (foundDate)
+            {
+                return false;
+            }
+
+            // Did we at least find a contains words
+            // and at least one group of numbers that could
+            // be a mileage total?
+            return confidence >= 2;
         }
     }
 }

--- a/Appserver/FormSubmit/MileageForm.cs
+++ b/Appserver/FormSubmit/MileageForm.cs
@@ -36,8 +36,18 @@ namespace Appserver.FormSubmit
 
             // Grab last row for total
             var lastrow = table.Last();
-            // Now remove it
-            table.RemoveAt(table.Count - 1);
+
+            // If lastrow is a total mileage row, remove it
+            if (isTotalMilesRow(lastrow))
+            {
+                table.RemoveAt(table.Count - 1);
+            }
+
+            // Only remove last row if it's a total Miles
+            if (lastrow.Count < 3)
+            {
+                table.RemoveAt(table.Count - 1);
+            }
 
             foreach (var row in table)
             {

--- a/Appserver/FormSubmit/TimesheetForm.cs
+++ b/Appserver/FormSubmit/TimesheetForm.cs
@@ -42,8 +42,18 @@ public class TimesheetForm: AbstractFormObject
 
         // Grab last row for total
         var lastrow = table.Last();
-        // Now remove it
-        table.RemoveAt(table.Count - 1);
+
+        // Check if lastrow is a total hours row.
+        // If so, remove it.
+        if (isTotalTimeRow(lastrow))
+        {
+            table.RemoveAt(table.Count - 1);
+        }
+
+        if (lastrow.Count < 3)
+        {
+            table.RemoveAt(table.Count - 1);
+        }
 
         foreach (var row in table)
         {

--- a/Appserver/FormSubmit/TimesheetForm.cs
+++ b/Appserver/FormSubmit/TimesheetForm.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Appserver.TextractDocument;
 using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 public class TimesheetForm: AbstractFormObject
 {
@@ -80,5 +81,33 @@ public class TimesheetForm: AbstractFormObject
                 totalHours = lastrow[3].ToString();
             }
         }
+    }
+
+    // If one of the rows in the cell matches the regex
+    // and there is also a row that can be parsed into hours,
+    // then we probably have a total hours cell. 
+    public static bool isTotalTimeRow(List<Cell> lastrow)
+    {
+        // The letters of "total/unit/hours" without
+        // "yes/no" for group field.
+        Regex rxTotal = new Regex(@"([uthrli])+");
+        Regex rxTime = new Regex(@"([0-9])+");
+        bool matchRex = false;
+        bool matchTime = false;
+
+        foreach (var entry in lastrow)
+        {
+            // TotalHours match?
+            var s = entry.ToString().Trim().ToLower();
+            var totalmatches = rxTotal.Matches(s);
+            if (totalmatches.Count >= 1) { matchRex = true; }
+
+            // Time match?
+            var time = FixHours(entry.ToString()).ToString().Trim();
+            var timeMatches = rxTime.Matches(time.ToLower());
+            if (timeMatches.Count >= 1) { matchTime = true; }
+        }
+
+        return matchRex && matchTime;
     }
 }


### PR DESCRIPTION
Prevents the last row of a table from being removed if it is likely to be a total units row.

Signed-off-by: Brian Lee <brialee@pdx.edu>